### PR TITLE
Geneticcode equals

### DIFF
--- a/.idea/-Alfa_Csapat_Proto.iml
+++ b/.idea/-Alfa_Csapat_Proto.iml
@@ -11,5 +11,21 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/src/main/com/teamalfa/blindvirologists/agents/Agent.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/Agent.java
@@ -17,9 +17,17 @@ abstract public class Agent {
         return geneticCode;
     }
 
+    public void setGeneticCode(GeneticCode code) {
+        geneticCode = code;
+    }
+
     abstract public void apply(Virologist target);
 
     public ElementBank getCost() {
         return cost;
+    }
+
+    public Virologist getTarget() {
+        return target;
     }
 }

--- a/src/main/com/teamalfa/blindvirologists/agents/genetic_code/AmnesiaCode.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/genetic_code/AmnesiaCode.java
@@ -5,6 +5,11 @@ import main.com.teamalfa.blindvirologists.agents.virus.AmnesiaVirus;
 import main.com.teamalfa.blindvirologists.virologist.backpack.ElementBank;
 
 public class AmnesiaCode extends GeneticCode {
+
+    public AmnesiaCode(){
+        this.type = "amnesia";
+    }
+
     /**
      * This method creates a Virus with the amnesia geneticcode.
      *

--- a/src/main/com/teamalfa/blindvirologists/agents/genetic_code/BearCode.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/genetic_code/BearCode.java
@@ -6,6 +6,11 @@ import main.com.teamalfa.blindvirologists.virologist.Virologist;
 import main.com.teamalfa.blindvirologists.virologist.backpack.ElementBank;
 
 public class BearCode extends GeneticCode {
+
+    public BearCode(){
+        this.type = "bear";
+    }
+
     /**
      * This method creates a Virus with the bear geneticcode.
      *

--- a/src/main/com/teamalfa/blindvirologists/agents/genetic_code/DanceCode.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/genetic_code/DanceCode.java
@@ -6,6 +6,10 @@ import main.com.teamalfa.blindvirologists.virologist.backpack.ElementBank;
 
 public class DanceCode extends GeneticCode{
 
+    public DanceCode(){
+        this.type = "dance";
+    }
+
     /**
      * This method creates a Virus with the dance geneticcode.
      * @return The DanceVirus that has been created.

--- a/src/main/com/teamalfa/blindvirologists/agents/genetic_code/GeneticCode.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/genetic_code/GeneticCode.java
@@ -9,6 +9,7 @@ import main.com.teamalfa.blindvirologists.virologist.backpack.ElementBank;
  *  further viruses and vaccines should implement all these functions
  */
 abstract public class GeneticCode {
+    protected String type;
     abstract public Virus createVirus(ElementBank elementBank);
     abstract public Vaccine createVaccine(ElementBank elementBank);
     public void autoInfect(Virologist virologist){  }

--- a/src/main/com/teamalfa/blindvirologists/agents/genetic_code/GeneticCode.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/genetic_code/GeneticCode.java
@@ -13,4 +13,16 @@ abstract public class GeneticCode {
     abstract public Virus createVirus(ElementBank elementBank);
     abstract public Vaccine createVaccine(ElementBank elementBank);
     public void autoInfect(Virologist virologist){  }
+    public String getType() { return type; }
+    @Override
+    public boolean equals(Object obj) {
+        // if compared to self true
+        if(obj == this) return true;
+        // if not genetic code false
+        if(!(obj instanceof GeneticCode)) return false;
+
+        // now it's safe to cast
+        GeneticCode code = (GeneticCode) obj;
+        return code.getType() == type;
+    }
 }

--- a/src/main/com/teamalfa/blindvirologists/agents/genetic_code/ParalyzeCode.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/genetic_code/ParalyzeCode.java
@@ -5,6 +5,10 @@ import main.com.teamalfa.blindvirologists.virologist.backpack.ElementBank;
 
 public class ParalyzeCode extends GeneticCode{
 
+    public ParalyzeCode(){
+        this.type = "paralyze";
+    }
+
     /**
      * This method creates a Virus with the paralyze geneticcode.
      * @return The ParalyzeVirus that has been created.

--- a/src/main/com/teamalfa/blindvirologists/agents/virus/AmnesiaVirus.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/virus/AmnesiaVirus.java
@@ -1,8 +1,13 @@
 package main.com.teamalfa.blindvirologists.agents.virus;
 
+import main.com.teamalfa.blindvirologists.agents.genetic_code.AmnesiaCode;
 import main.com.teamalfa.blindvirologists.virologist.Virologist;
 
 public class AmnesiaVirus extends Virus {
+
+    public AmnesiaVirus() {
+        geneticCode = new AmnesiaCode();
+    }
 
     /**
      * This method is called when the Virus is applied to a Virologist.

--- a/src/main/com/teamalfa/blindvirologists/agents/virus/BearVirus.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/virus/BearVirus.java
@@ -1,8 +1,13 @@
 package main.com.teamalfa.blindvirologists.agents.virus;
 
+import main.com.teamalfa.blindvirologists.agents.genetic_code.BearCode;
 import main.com.teamalfa.blindvirologists.virologist.Virologist;
 
 public class BearVirus extends DanceVirus{
+
+    public BearVirus(){
+        geneticCode = new BearCode();
+    }
 
     /**
      * This method infects the Virologist,

--- a/src/main/com/teamalfa/blindvirologists/agents/virus/DanceVirus.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/virus/DanceVirus.java
@@ -1,5 +1,6 @@
 package main.com.teamalfa.blindvirologists.agents.virus;
 
+import main.com.teamalfa.blindvirologists.agents.genetic_code.DanceCode;
 import main.com.teamalfa.blindvirologists.city.fields.Field;
 import main.com.teamalfa.blindvirologists.random.MyRandom;
 import main.com.teamalfa.blindvirologists.random.TrueRandom;
@@ -10,6 +11,7 @@ public class DanceVirus extends Virus {
 
     public DanceVirus(){
         this.random = new TrueRandom();
+        geneticCode = new DanceCode();
     }
 
     public void setRandom(MyRandom random){

--- a/src/main/com/teamalfa/blindvirologists/agents/virus/ParalyzeVirus.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/virus/ParalyzeVirus.java
@@ -1,8 +1,13 @@
 package main.com.teamalfa.blindvirologists.agents.virus;
 
+import main.com.teamalfa.blindvirologists.agents.genetic_code.ParalyzeCode;
 import main.com.teamalfa.blindvirologists.city.fields.Field;
 
 public class ParalyzeVirus extends Virus {
+
+    public ParalyzeVirus() {
+        geneticCode = new ParalyzeCode();
+    }
 
     /**
      * This method doesnt let the Virologist leave their current Field while being affected by the Virus.

--- a/src/main/com/teamalfa/blindvirologists/agents/virus/Virus.java
+++ b/src/main/com/teamalfa/blindvirologists/agents/virus/Virus.java
@@ -16,7 +16,7 @@ abstract public class Virus extends Agent {
     @Override
     public void apply(Virologist target) {
         if (target.infectedBy(this)) {
-            this.addVirologist(target);
+            this.target = target;
         }
     }
 

--- a/src/main/com/teamalfa/blindvirologists/equipments/active_equipments/Gloves.java
+++ b/src/main/com/teamalfa/blindvirologists/equipments/active_equipments/Gloves.java
@@ -17,4 +17,9 @@ public class Gloves extends ActiveEquipment {
         //AController.printReturn(null);
          */
     }
+
+    @Override
+    public void wornOut() {
+        // TODO:
+    }
 }

--- a/src/main/com/teamalfa/blindvirologists/virologist/Virologist.java
+++ b/src/main/com/teamalfa/blindvirologists/virologist/Virologist.java
@@ -1,6 +1,7 @@
 package main.com.teamalfa.blindvirologists.virologist;
 
 import main.com.teamalfa.blindvirologists.agents.Agent;
+import main.com.teamalfa.blindvirologists.agents.GeneticCodeBank;
 import main.com.teamalfa.blindvirologists.agents.Vaccine;
 import main.com.teamalfa.blindvirologists.agents.genetic_code.GeneticCode;
 import main.com.teamalfa.blindvirologists.agents.virus.Virus;
@@ -117,20 +118,23 @@ public class Virologist {
      * @return true if rhe infection was successful, otherwise it returns false.
      */
     public boolean infectedBy(Virus virus) {
-        Boolean ret = true;
 
-        // check if protected by any vaccine
-        if(protectionBank.contains(virus.getGeneticCode())) {
-            ret = false;
-        }else {
-            // check if protected by any equipment
-            for(Equipment equipment : wornEquipment)
-                if(equipment.protect())
-                    ret = false;
+        // check vaccine protection
+        for(GeneticCode code : protectionBank) {
+            if(code.equals(virus.getGeneticCode())) {
+                return false;
+            }
         }
-        //activeViruses.add(virus);
 
-        return ret;
+        // check equipment protection
+        for(Equipment equipment : wornEquipment) {
+            if(equipment.protect()) {
+                return false;
+            }
+        }
+
+        activeViruses.add(virus);
+        return true;
     }
 
     /**

--- a/src/test/com/teamalfa/blindvirologists/agents/genetic_code/GeneticCodeTest.java
+++ b/src/test/com/teamalfa/blindvirologists/agents/genetic_code/GeneticCodeTest.java
@@ -1,0 +1,52 @@
+package test.com.teamalfa.blindvirologists.agents.genetic_code;
+
+import main.com.teamalfa.blindvirologists.agents.genetic_code.*;
+import main.com.teamalfa.blindvirologists.virologist.Virologist;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GeneticCodeTest {
+    static AmnesiaCode a1, a2;
+    static BearCode b1, b2;
+    static DanceCode d1, d2;
+    static ParalyzeCode p1, p2;
+    static Virologist v1;
+
+    @BeforeAll
+    static void setUp() {
+        a1 = new AmnesiaCode(); a2 = new AmnesiaCode();
+        b1 = new BearCode(); b2 = new BearCode();
+        d1 = new DanceCode(); d2 = new DanceCode();
+        p1 = new ParalyzeCode(); p2 = new ParalyzeCode();
+        v1 = new Virologist();
+    }
+
+    @Test
+    void testSameGeneticCodes(){
+        String msg = "Codes should be equal.";
+        assertTrue(a1.equals(a2), msg);
+        assertTrue(b1.equals(b2), msg);
+        assertTrue(d1.equals(d2), msg);
+        assertTrue(p1.equals(p2), msg);
+    }
+
+    @Test
+    void testDifferentGeneticCodes(){
+        String msg = "Codes should not be equal";
+        assertFalse(a1.equals(p2), msg);
+        assertFalse(b1.equals(d2), msg);
+        assertFalse(d1.equals(b2), msg);
+        assertFalse(p1.equals(a2), msg);
+    }
+
+    @Test
+    void testDifferentTypeObjectGeneticCodes() {
+        String msg = "Code should not be equal to different types of object.";
+        assertFalse(a1.equals(v1), msg);
+        assertFalse(b1.equals(v1), msg);
+        assertFalse(d1.equals(v1), msg);
+        assertFalse(p1.equals(v1), msg);
+    }
+}

--- a/src/test/com/teamalfa/blindvirologists/virologist/VirologistInfectionTest.java
+++ b/src/test/com/teamalfa/blindvirologists/virologist/VirologistInfectionTest.java
@@ -1,0 +1,71 @@
+package test.com.teamalfa.blindvirologists.virologist;
+
+import main.com.teamalfa.blindvirologists.agents.GeneticCodeBank;
+import main.com.teamalfa.blindvirologists.agents.Vaccine;
+import main.com.teamalfa.blindvirologists.agents.genetic_code.GeneticCode;
+import main.com.teamalfa.blindvirologists.agents.virus.Virus;
+import main.com.teamalfa.blindvirologists.equipments.Equipment;
+import main.com.teamalfa.blindvirologists.virologist.Virologist;
+import main.com.teamalfa.blindvirologists.virologist.backpack.ElementBank;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VirologistInfectionTest {
+    static Virologist virologist;
+    static ArrayList<GeneticCode> geneticCodes;
+    static ElementBank elementBank;
+
+    @BeforeAll
+    static void setUp(){
+        geneticCodes = GeneticCodeBank.getInstance().getCodes();
+    }
+
+    @BeforeEach
+    void reset(){
+        virologist = new Virologist();
+        elementBank = new ElementBank(1000,1000);
+    }
+
+    @Test
+    void normalVirologistInfection(){
+        // In normal circumstances a virus should infect a virologist
+        // which means that the viruses target is set to the virologist
+        // and the virus gets placed into the virologists active viruses
+        // array.
+        for(GeneticCode code : geneticCodes) {
+            //create virus from code and apply to virologist
+            Virus virus = code.createVirus(elementBank);
+            virus.apply(virologist);
+
+            assertEquals(virus.getTarget(), virologist,
+                    "The target should be equal to the virologist.");
+            assertTrue(virologist.getViruses().contains(virus),
+                    "The virus should be in the active viruses array.");
+        }
+    }
+
+    @Test
+    void vaccinatedVirologistInfection(){
+        // If a virologist is vaccinated against a virus then
+        // it should have no effect on the virologist.
+        for(GeneticCode code : geneticCodes) {
+            // create vaccine from code and apply to virologist
+            Vaccine vaccine = code.createVaccine(elementBank);
+            vaccine.apply(virologist);
+
+            // create virus code and apply to virologist
+            Virus virus = code.createVirus(elementBank);
+            virus.apply(virologist);
+
+            assertNotEquals(virus.getTarget(), virologist,
+                    "The target should not be equal to the virologist.");
+            assertFalse(virologist.getViruses().contains(virus),
+                    "The virus should not be in the active viruses array.");
+        }
+    }
+}


### PR DESCRIPTION
Overrode the GenetiCode's equal method to compare codes by their type. It's a private string attribute.
Wrote some jUnit tests for it and of course all of them passed.

Also modified the virologist's infectedBy method to reflect these changes.
Made jUnit tests for this as well. Viruses were missing their genetic codes so fixed that too.